### PR TITLE
Support both v1, v2, etc as version directories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <artifactId>dd-data-vault</artifactId>
     <version>0.1.1-SNAPSHOT</version>
 
-    <name>Dd Data Vault</name>
+    <name>DD Data Vault</name>
     <url>https://github.com/DANS-KNAW/dd-data-vault</url>
     <description>Manages a DANS Data Vault store</description>
     <inceptionYear>2024</inceptionYear>
@@ -71,22 +71,20 @@
         <dependency>
             <groupId>nl.knaw.dans</groupId>
             <artifactId>dans-ocfl-java-extensions-lib</artifactId>
-            <version>0.1.1-SNAPSHOT</version>
+            <version>0.2.0</version>
         </dependency>
         <dependency>
             <groupId>io.ocfl</groupId>
             <artifactId>ocfl-java-api</artifactId>
-            <version>2.0.0</version>
         </dependency>
         <dependency>
             <groupId>io.ocfl</groupId>
             <artifactId>ocfl-java-core</artifactId>
-            <version>2.0.0</version>
         </dependency>
         <dependency>
             <groupId>nl.knaw.dans</groupId>
             <artifactId>dans-java-utils</artifactId>
-            <version>0.9.1-SNAPSHOT</version>
+            <version>0.10.1</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <properties>
         <main-class>nl.knaw.dans.datavault.DdDataVaultApplication</main-class>
-        <dd-data-vault-api.version>0.1.1-SNAPSHOT</dd-data-vault-api.version>
+        <dd-data-vault-api.version>0.2.0</dd-data-vault-api.version>
     </properties>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <properties>
         <main-class>nl.knaw.dans.datavault.DdDataVaultApplication</main-class>
-        <dd-data-vault-api.version>0.1.0</dd-data-vault-api.version>
+        <dd-data-vault-api.version>0.1.1-SNAPSHOT</dd-data-vault-api.version>
     </properties>
 
     <scm>
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>nl.knaw.dans</groupId>
             <artifactId>dans-ocfl-java-extensions-lib</artifactId>
-            <version>0.1.0</version>
+            <version>0.1.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.ocfl</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
         <dependency>
             <groupId>nl.knaw.dans</groupId>
             <artifactId>dans-java-utils</artifactId>
+            <version>0.9.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/nl/knaw/dans/datavault/core/OcflRepositoryProvider.java
+++ b/src/main/java/nl/knaw/dans/datavault/core/OcflRepositoryProvider.java
@@ -53,13 +53,24 @@ public class OcflRepositoryProvider implements RepositoryProvider, Managed {
 
     // TODO: add user name and email and message to the method
     @Override
-    public void addVersion(String objectId, Path objectVersionDirectory) {
-        log.debug("Adding version {} to object {}", objectVersionDirectory, objectId);
+    public void addVersion(String objectId, int version, Path objectVersionDirectory) {
+        log.debug("Adding version import directory {} to object {} as version v{}", objectVersionDirectory, objectId, version);
+        if (ocflRepository == null) {
+            throw new IllegalStateException("OCFL repository is not yet started");
+        }
+        // putObject wants the version number of HEAD, so we need to subtract 1 from the version number
+        ocflRepository.putObject(ObjectVersionId.version(objectId, version - 1), objectVersionDirectory, createVersionInfo("default message"));
+    }
+
+    @Override
+    public void addHeadVersion(String objectId, Path objectVersionDirectory) {
+        log.debug("Adding version import directory {} to object {} as head version", objectVersionDirectory, objectId);
         if (ocflRepository == null) {
             throw new IllegalStateException("OCFL repository is not yet started");
         }
         ocflRepository.putObject(ObjectVersionId.head(objectId), objectVersionDirectory, createVersionInfo("default message"));
     }
+
     private VersionInfo createVersionInfo(String message) {
         return new VersionInfo()
             .setMessage(message)

--- a/src/main/java/nl/knaw/dans/datavault/core/RepositoryProvider.java
+++ b/src/main/java/nl/knaw/dans/datavault/core/RepositoryProvider.java
@@ -25,11 +25,21 @@ import java.nio.file.Path;
 public interface RepositoryProvider extends Managed {
 
     /**
-     * Adds a new version to the object identified by the given object id. If the object does not exist yet, it will be created.
+     * Adds a new version to the object identified by the given object id. If the object does not exist yet, it will be created. Note that the version number must be the next version number in the
+     * sequence of versions for the object.
      *
      * @param objectId               The identifier of the object
+     * @param version                The version number of the new version
      * @param objectVersionDirectory The directory containing the new version of the object
      */
-    void addVersion(String objectId, Path objectVersionDirectory);
+    void addVersion(String objectId, int version, Path objectVersionDirectory);
+
+    /**
+     * Adds a new head version to the object identified by the given object id. If the object does not exist yet, it will be created.
+     *
+     * @param objectId               The identifier of the object
+     * @param objectVersionDirectory The directory containing the new head version of the object
+     */
+    void addHeadVersion(String objectId, Path objectVersionDirectory);
 
 }

--- a/src/main/java/nl/knaw/dans/datavault/core/UnitOfWorkDeclaringRepositoryProviderAdapter.java
+++ b/src/main/java/nl/knaw/dans/datavault/core/UnitOfWorkDeclaringRepositoryProviderAdapter.java
@@ -26,8 +26,14 @@ public class UnitOfWorkDeclaringRepositoryProviderAdapter implements RepositoryP
 
     @Override
     @UnitOfWork
-    public void addVersion(String objectId, Path objectVersionDirectory) {
-        delegate.addVersion(objectId, objectVersionDirectory);
+    public void addVersion(String objectId, int version, Path objectVersionDirectory) {
+        delegate.addVersion(objectId, version, objectVersionDirectory);
+    }
+
+    @Override
+    @UnitOfWork
+    public void addHeadVersion(String objectId, Path objectVersionDirectory) {
+        delegate.addHeadVersion(objectId, objectVersionDirectory);
     }
 
     @Override

--- a/src/main/java/nl/knaw/dans/datavault/resources/LayersApiResource.java
+++ b/src/main/java/nl/knaw/dans/datavault/resources/LayersApiResource.java
@@ -20,6 +20,7 @@ import nl.knaw.dans.datavault.api.LayerStatusDto;
 import nl.knaw.dans.layerstore.LayerManager;
 
 import javax.ws.rs.core.Response;
+import java.io.IOException;
 
 import static javax.ws.rs.core.Response.Status.CREATED;
 
@@ -28,9 +29,40 @@ public class LayersApiResource implements LayersApi {
     private final LayerManager layerManager;
 
     @Override
+    public Response layersLayerIdGet(Long layerId) {
+        try {
+            var layer = layerManager.getLayer(layerId);
+            return Response.ok(new LayerStatusDto()
+                    .layerId(layer.getId())
+                    .sizeInBytes(layer.getSizeInBytes()))
+                .build();
+        }
+        catch (IllegalArgumentException e) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        catch (IOException e) {
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    @Override
     public Response layersPost() {
         layerManager.newTopLayer();
         return Response.status(CREATED).entity(new LayerStatusDto().layerId(layerManager.getTopLayer().getId())).build();
         // TODO: error handling
+    }
+
+    @Override
+    public Response layersTopGet() {
+        var topLayer = layerManager.getTopLayer();
+        try {
+            return Response.ok(new LayerStatusDto()
+                    .layerId(topLayer.getId())
+                    .sizeInBytes(topLayer.getSizeInBytes()))
+                .build();
+        }
+        catch (IOException e) {
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
+        }
     }
 }


### PR DESCRIPTION
Fixes DD-1492

# Description of changes
By default, now expect the version import directories in an object import directory to be in v<sub>n</sub> format instead of a timestamp.



# Notify
@DANS-KNAW/core-systems
