### PR TITLE
DD-1964 default version info 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,11 @@
             <artifactId>dans-java-utils</artifactId>
         </dependency>
         <dependency>
+            <groupId>nl.knaw.dans</groupId>
+            <artifactId>dans-validation-lib</artifactId>
+            <version>1.1.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>

--- a/src/main/assembly/dist/cfg/config.yml
+++ b/src/main/assembly/dist/cfg/config.yml
@@ -67,6 +67,15 @@ dataVault:
   ocflRepository:
     workDir: /data/vault/tmp
 
+  defaultUserInfo:
+    #
+    # Default user information to be used when no user information is provided when adding an object version. Currently, there is no way to
+    # provide user information when adding an object version, so this is the only way to set user information.
+    #
+    username: changeme
+    email: changeme@example.com
+    message: change me
+
   #
   # Settings for the layer store in which the data vault stores its data.
   #

--- a/src/main/assembly/dist/cfg/config.yml
+++ b/src/main/assembly/dist/cfg/config.yml
@@ -67,11 +67,11 @@ dataVault:
   ocflRepository:
     workDir: /data/vault/tmp
 
-  defaultUserInfo:
-    #
-    # Default user information to be used when no user information is provided when adding an object version. Currently, there is no way to
-    # provide user information when adding an object version, so this is the only way to set user information.
-    #
+  #
+  # Default version information to be used when no version information is provided when adding an object version. Currently, there is no way to
+  # provide version information when adding an object version, so this is the only way to set user information.
+  #
+  defaultVersionInfo:
     username: changeme
     email: changeme@example.com
     message: change me

--- a/src/main/java/nl/knaw/dans/datavault/DdDataVaultApplication.java
+++ b/src/main/java/nl/knaw/dans/datavault/DdDataVaultApplication.java
@@ -82,6 +82,7 @@ public class DdDataVaultApplication extends Application<DdDataVaultConfig> {
             var itemStore = new LayeredItemStore(dao, layerManager, new StoreInventoryDbBackedContentManager());
             var ocflRepositoryProvider = createUnitOfWorkAwareProxy(OcflRepositoryProvider.builder()
                 .itemStore(itemStore)
+                .defaultUserInfoConfig(configuration.getDataVault().getDefaultUserInfo())
                 .workDir(configuration.getDataVault().getOcflRepository().getWorkDir())
                 .build());
             environment.lifecycle().manage(ocflRepositoryProvider);

--- a/src/main/java/nl/knaw/dans/datavault/DdDataVaultApplication.java
+++ b/src/main/java/nl/knaw/dans/datavault/DdDataVaultApplication.java
@@ -82,7 +82,7 @@ public class DdDataVaultApplication extends Application<DdDataVaultConfig> {
             var itemStore = new LayeredItemStore(dao, layerManager, new StoreInventoryDbBackedContentManager());
             var ocflRepositoryProvider = createUnitOfWorkAwareProxy(OcflRepositoryProvider.builder()
                 .itemStore(itemStore)
-                .defaultUserInfoConfig(configuration.getDataVault().getDefaultUserInfo())
+                .defaultVersionInfoConfig(configuration.getDataVault().getDefaultVersionInfo())
                 .workDir(configuration.getDataVault().getOcflRepository().getWorkDir())
                 .build());
             environment.lifecycle().manage(ocflRepositoryProvider);

--- a/src/main/java/nl/knaw/dans/datavault/config/DataVaultConfig.java
+++ b/src/main/java/nl/knaw/dans/datavault/config/DataVaultConfig.java
@@ -32,7 +32,7 @@ public class DataVaultConfig {
     private OcflRepositoryConfig ocflRepository;
     @NotNull
     @Valid
-    private DefaultUserInfoConfig defaultUserInfo;
+    private DefaultVersionInfoConfig defaultVersionInfo;
     @NotNull
     private LayerStoreConfig layerStore;
 }

--- a/src/main/java/nl/knaw/dans/datavault/config/DefaultUserInfoConfig.java
+++ b/src/main/java/nl/knaw/dans/datavault/config/DefaultUserInfoConfig.java
@@ -16,23 +16,18 @@
 package nl.knaw.dans.datavault.config;
 
 import lombok.Data;
+import nl.knaw.dans.validation.AllowedUriSchemes;
 
-import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import java.net.URI;
 
 @Data
-public class DataVaultConfig {
+public class DefaultUserInfoConfig {
     @NotNull
-    private String validObjectIdentifierPattern;
+    private String username;
     @NotNull
-    @Valid
-    private IngestConfig ingest;
-
+    @AllowedUriSchemes(schemes = "mailto")
+    private URI email;
     @NotNull
-    private OcflRepositoryConfig ocflRepository;
-    @NotNull
-    @Valid
-    private DefaultUserInfoConfig defaultUserInfo;
-    @NotNull
-    private LayerStoreConfig layerStore;
+    private String message;
 }

--- a/src/main/java/nl/knaw/dans/datavault/config/DefaultVersionInfoConfig.java
+++ b/src/main/java/nl/knaw/dans/datavault/config/DefaultVersionInfoConfig.java
@@ -22,7 +22,7 @@ import javax.validation.constraints.NotNull;
 import java.net.URI;
 
 @Data
-public class DefaultUserInfoConfig {
+public class DefaultVersionInfoConfig {
     @NotNull
     private String username;
     @NotNull

--- a/src/main/java/nl/knaw/dans/datavault/core/ImportJob.java
+++ b/src/main/java/nl/knaw/dans/datavault/core/ImportJob.java
@@ -105,7 +105,7 @@ public class ImportJob implements Runnable {
             status = Status.FAILED;
         }
         catch (IllegalArgumentException e) {
-            log.error("Invalid batch layout for batch directory {}", path, e);
+            log.error("Invalid batch layout for batch directory {}. Leaving input in place.", path, e);
             status = Status.FAILED;
         }
         finally {
@@ -174,7 +174,7 @@ public class ImportJob implements Runnable {
 
         if (!invalidObjectDirectories.isEmpty() || !invalidVersionDirectories.isEmpty()) {
             throw new IllegalArgumentException("Invalid batch layout: " +
-                "invalid object directories (name must match configured pattern): " + invalidObjectDirectories +
+                "invalid object directories (name must match configured pattern '" + validObjectIdentifierPattern + "'): " + invalidObjectDirectories +
                 ", invalid version directories (name must follow vN pattern or be a number, depending on configuration): " + invalidVersionDirectories);
         }
         log.debug("Batch layout for batch directory {} is valid", path);

--- a/src/main/java/nl/knaw/dans/datavault/core/OcflRepositoryProvider.java
+++ b/src/main/java/nl/knaw/dans/datavault/core/OcflRepositoryProvider.java
@@ -28,7 +28,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.datavault.api.OcflObjectVersionDto;
-import nl.knaw.dans.datavault.config.DefaultUserInfoConfig;
+import nl.knaw.dans.datavault.config.DefaultVersionInfoConfig;
 import nl.knaw.dans.layerstore.ItemStore;
 import nl.knaw.dans.lib.ocflext.LayeredStorage;
 
@@ -45,13 +45,13 @@ public class OcflRepositoryProvider implements RepositoryProvider, Managed {
     private Path workDir;
 
     @NonNull
-    private DefaultUserInfoConfig defaultUserInfoConfig;
+    private DefaultVersionInfoConfig defaultVersionInfoConfig;
 
     private OcflRepository ocflRepository;
 
     @Builder
-    public static OcflRepositoryProvider create(ItemStore itemStore, Path workDir, DefaultUserInfoConfig defaultUserInfoConfig) {
-        return new OcflRepositoryProvider(itemStore, workDir, defaultUserInfoConfig);
+    public static OcflRepositoryProvider create(ItemStore itemStore, Path workDir, DefaultVersionInfoConfig defaultVersionInfoConfig) {
+        return new OcflRepositoryProvider(itemStore, workDir, defaultVersionInfoConfig);
     }
 
     // TODO: add user name and email and message to the method
@@ -83,10 +83,10 @@ public class OcflRepositoryProvider implements RepositoryProvider, Managed {
 
     private VersionInfo createVersionInfo() {
         return new VersionInfo()
-            .setMessage(defaultUserInfoConfig.getMessage())
+            .setMessage(defaultVersionInfoConfig.getMessage())
             .setUser(new User()
-                .setName(defaultUserInfoConfig.getUsername())
-                .setAddress(defaultUserInfoConfig.getEmail().toString())
+                .setName(defaultVersionInfoConfig.getUsername())
+                .setAddress(defaultVersionInfoConfig.getEmail().toString())
             );
     }
 

--- a/src/main/java/nl/knaw/dans/datavault/core/OcflRepositoryProvider.java
+++ b/src/main/java/nl/knaw/dans/datavault/core/OcflRepositoryProvider.java
@@ -28,6 +28,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.datavault.api.OcflObjectVersionDto;
+import nl.knaw.dans.datavault.config.DefaultUserInfoConfig;
 import nl.knaw.dans.layerstore.ItemStore;
 import nl.knaw.dans.lib.ocflext.LayeredStorage;
 
@@ -43,11 +44,14 @@ public class OcflRepositoryProvider implements RepositoryProvider, Managed {
     @NonNull
     private Path workDir;
 
+    @NonNull
+    private DefaultUserInfoConfig defaultUserInfoConfig;
+
     private OcflRepository ocflRepository;
 
     @Builder
-    public static OcflRepositoryProvider create(ItemStore itemStore, Path workDir) {
-        return new OcflRepositoryProvider(itemStore, workDir);
+    public static OcflRepositoryProvider create(ItemStore itemStore, Path workDir, DefaultUserInfoConfig defaultUserInfoConfig) {
+        return new OcflRepositoryProvider(itemStore, workDir, defaultUserInfoConfig);
     }
 
     // TODO: add user name and email and message to the method
@@ -58,7 +62,7 @@ public class OcflRepositoryProvider implements RepositoryProvider, Managed {
             throw new IllegalStateException("OCFL repository is not yet started");
         }
         // putObject wants the version number of HEAD, so we need to subtract 1 from the version number
-        ocflRepository.putObject(ObjectVersionId.version(objectId, version - 1), objectVersionDirectory, createVersionInfo("default message"));
+        ocflRepository.putObject(ObjectVersionId.version(objectId, version - 1), objectVersionDirectory, createVersionInfo());
     }
 
     @Override
@@ -67,7 +71,7 @@ public class OcflRepositoryProvider implements RepositoryProvider, Managed {
         if (ocflRepository == null) {
             throw new IllegalStateException("OCFL repository is not yet started");
         }
-        ocflRepository.putObject(ObjectVersionId.head(objectId), objectVersionDirectory, createVersionInfo("default message"));
+        ocflRepository.putObject(ObjectVersionId.head(objectId), objectVersionDirectory, createVersionInfo());
     }
 
     @Override
@@ -77,12 +81,12 @@ public class OcflRepositoryProvider implements RepositoryProvider, Managed {
             .versionNumber(version).created(versionInfo.getCreated());
     }
 
-    private VersionInfo createVersionInfo(String message) {
+    private VersionInfo createVersionInfo() {
         return new VersionInfo()
-            .setMessage(message)
+            .setMessage(defaultUserInfoConfig.getMessage())
             .setUser(new User()
-                .setName("test-user")
-                .setAddress("mailto:somebody@dans.knaw.nl")
+                .setName(defaultUserInfoConfig.getUsername())
+                .setAddress(defaultUserInfoConfig.getEmail().toString())
             );
     }
 

--- a/src/test/resources/debug-etc/config.yml
+++ b/src/test/resources/debug-etc/config.yml
@@ -50,6 +50,15 @@ dataVault:
     workDir: data/ocfl-work
 
   #
+  # Default version information to be used when no version information is provided when adding an object version. Currently, there is no way to
+  # provide version information when adding an object version, so this is the only way to set user information.
+  #
+  defaultVersionInfo:
+    username: changeme
+    email: changeme@example.com
+    message: change me
+
+  #
   # Settings for the layer store in which the data vault stores its data.
   #
   layerStore:


### PR DESCRIPTION
Fixes DD-1964

# Description of changes
Adds a new configuration section that lets you specify the default version info to be used when creating new object version.

# Notify
@DANS-KNAW/core-systems
